### PR TITLE
Fix daily score when clearing all cells

### DIFF
--- a/src/components/SleepTracker.tsx
+++ b/src/components/SleepTracker.tsx
@@ -62,8 +62,10 @@ const SleepTracker = () => {
       // Count cells of each color for this date
       for (const metricId in cellColors[date]) {
         const color = cellColors[date][metricId];
+        if (!color) continue; // ignore cells with no color assigned
+
         totalCells++;
-        
+
         if (color === 'format-error') {
           redCells++;
         } else if (color === 'format-warning') {
@@ -147,7 +149,18 @@ const SleepTracker = () => {
       if (!newColors[date]) {
         newColors[date] = {};
       }
-      newColors[date][metricId] = color;
+
+      if (color) {
+        newColors[date][metricId] = color;
+      } else {
+        if (newColors[date]) {
+          delete newColors[date][metricId];
+          if (Object.keys(newColors[date]).length === 0) {
+            delete newColors[date];
+          }
+        }
+      }
+
       return newColors;
     });
   };


### PR DESCRIPTION
## Summary
- skip uncolored cells when calculating daily scores
- delete color entries when color reset to empty

## Testing
- `npm run lint`
